### PR TITLE
creación del job para finalizar partida

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: vendor/bin/heroku-php-apache2 public/
+supervisor: supervisord -c supervisor.conf -n 

--- a/app/Jobs/FinishGame.php
+++ b/app/Jobs/FinishGame.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Game;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class FinishGame implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    protected $game;
+    /**
+     * Create a new job instance.
+     *
+     * @return void
+     */
+    public function __construct(Game $game)
+    {
+        $this->game = $game->withoutRelations();
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        if($this->game->state!=2){
+            $this->game->state = 2;
+            $this->game->save();
+        }
+        
+    }
+}

--- a/app/Services/CommandService.php
+++ b/app/Services/CommandService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use App\Jobs\FinishGame;
 use App\Models\TelegramUser;
 use App\Models\Game;
 use App\Models\Message;
@@ -82,6 +83,8 @@ class CommandService
     $this->message->createMessage($game->id, $id, $update_id, '/nuevo', 0, $date);
     $this->message->createMessage($game->id, $id, $update_id, $message, 1, $date + 1);
     $this->state->createState($game->id, $board_state, 0, 1, $date);
+
+    FinishGame::dispatch($game)->delay(now()->addMinutes(15));
   }
 
   public function updateState($id, $board_state, $transmitter)

--- a/config/queue.php
+++ b/config/queue.php
@@ -13,7 +13,7 @@ return [
     |
     */
 
-    'default' => env('QUEUE_CONNECTION', 'sync'),
+    'default' => env('QUEUE_CONNECTION', 'database'),
 
     /*
     |--------------------------------------------------------------------------

--- a/database/migrations/2021_09_02_205124_create_jobs_table.php
+++ b/database/migrations/2021_09_02_205124_create_jobs_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateJobsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('jobs', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('queue')->index();
+            $table->longText('payload');
+            $table->unsignedTinyInteger('attempts');
+            $table->unsignedInteger('reserved_at')->nullable();
+            $table->unsignedInteger('available_at');
+            $table->unsignedInteger('created_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('jobs');
+    }
+}

--- a/laravel-worker.conf
+++ b/laravel-worker.conf
@@ -1,0 +1,8 @@
+[program:laravel-worker]
+process_name=%(program_name)s_%(process_num)02d
+command=php /app/artisan queue:work --memory=64
+autostart=true
+autorestart=true
+numprocs=1
+redirect_stderr=true
+stdout_logfile=/app/worker.log

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+supervisor

--- a/supervisor.conf
+++ b/supervisor.conf
@@ -1,0 +1,15 @@
+[supervisord]
+logfile = /tmp/supervisord.log
+logfile_maxbytes = 50MB
+logfile_backups=10
+loglevel = info
+pidfile = /tmp/supervisord.pid
+nodaemon = true
+[inet_http_server]
+port=127.0.0.1:9001
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+[supervisorctl]
+serverurl=http://127.0.0.1:9001
+[include]
+files = laravel-worker.conf


### PR DESCRIPTION
Se creo un job para realizar la finalización de la partida automáticamente 15 min después de iniciar un nuevo juego. Este se encuentra en app/Jobs. 

Se utilizaron las [Queue](https://laravel.com/docs/8.x/queues#generating-job-classes) usando la base de datos, por lo tanto se creo una nueva migración automáticamente que es para los jobs.

Entonces estos procesos se encolan cada vez que se inicia un nuevo juego y en caso de que el juego haya finalizado no hace nada, pero si no esta finalizado lo termina.

En la configuración se puede elegir más procesos para que respondan a las tareas, pero solo puse 1 por el momento, hice una prueba enviando alrededor de 20 mensajes y todos los respondió sin problema. 

Para mantener trabajando a los jobs en el servidor fue necesario hacer unos pasos adicionales en el server, para eso utilice la siguiente guía.  https://smartupload.medium.com/running-laravel-7-x-8-x-on-heroku-5ed13fcd4851

Por defecto la bandera para ejecutar el comando de procfile esta desactivada, es necesario activarla desde heroku para que se ejecuten los procesos y queden a la escucha.




