### PR TITLE
Permite hacer rollback a la migracion ALTER_message_TABLE

### DIFF
--- a/database/migrations/2021_08_30_200306_alter_mesages_table_charset.php
+++ b/database/migrations/2021_08_30_200306_alter_mesages_table_charset.php
@@ -24,7 +24,7 @@ class AlterMesagesTableCharset extends Migration
      */
     public function down()
     {
-        DB::statement("ALTER TABLE messages CHANGE message message TEXT CHARACTER SET utf8 COLLATE utf8_general_ci;");
+        DB::statement("ALTER TABLE messages CHANGE message message TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;");
 
     }
 }


### PR DESCRIPTION
No se permitía hacer el rollback ya que la consulta en el método down() seguía con notación utf8. Se cambió la consulta a notación utf8mb4.