### PR TITLE
Cambia bases de datos para tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,8 +21,8 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.0
-          extensions: curl, pdo, pdo_psql
+          php-version: 8.2
+          extensions: curl, pdo
           coverage: none
 
       - name: Install Composer dependencies


### PR DESCRIPTION
MySQL -> PostgreSQL

Para quitar tests de la bdd principal y probar el funcionamiento de este servicio de heroku. 