### PR TITLE
arreglo de id duplicado

### DIFF
--- a/app/Models/Game.php
+++ b/app/Models/Game.php
@@ -60,10 +60,9 @@ class Game extends Model
     /**
      * Change a new game
      */
-    public function createGame($id,$telegram_user_id,$date,$opponent=false)
+    public function createGame($telegram_user_id,$date,$opponent=false)
     {
         return Game::create([
-            'id' => $id,
             'telegram_user_id' => $telegram_user_id,
             'date' => $date,
             'opponent' => !$opponent

--- a/app/Services/Gato.php
+++ b/app/Services/Gato.php
@@ -34,15 +34,17 @@ class Gato {
 
   // Bot(true) or human(false) second player
   private static $practice_game;
-  public $game_id;
+  private $game_id;
   public $turn; //To save the last user who has been played. ('agent', 'user')
+  private $msg_id;
 
-  public function __construct(int $w, int $b, bool $practice_game, string $id) {
+  public function __construct(int $w, int $b, bool $practice_game, string $id,string $msg_id) {
     self::$white = $w;
     self::$black = $b;
     self::$practice_game = $practice_game;
     $this->game_id = $id;
     $this->turn = 'agent';
+    $this->msg_id = $msg_id;
   }
 
   // Checks if a given bitmask is in a winning state
@@ -95,8 +97,8 @@ class Gato {
       else if (($mask & self::$black) != 0)
         $tile = 'X';
 
-      //        symbol, idx,      bitmask p1,        bitmask p1,      player type,            game_id             last_player
-      $data = "{$tile},{$i}," . self::$white . ','. self::$black.','.self::$practice_game.','.$this->game_id.','.$this->turn;
+      //        symbol, idx,      bitmask p1,        bitmask p1,      player type,            game_id             last_player       msg_id
+      $data = "{$tile},{$i}," . self::$white . ','. self::$black.','.self::$practice_game.','.$this->game_id.','.$this->turn .','. $this->msg_id;
       array_push($row, array("text" => $tile, "callback_data" => $data));
     }
 
@@ -155,11 +157,11 @@ class Gato {
   }
 
   public function game_state(): string {
-    return " , ," . self::$white . ','. self::$black . ',' . self::$practice_game . ',' . $this->game_id.','.$this->turn;
+    return " , ," . self::$white . ','. self::$black . ',' . self::$practice_game . ',' . $this->game_id.','.$this->turn .','. $this->msg_id;
   }
 
-  public static function new_game(bool $practice_game, string $game_id): array {
-    $gato = new Gato(0, 0, $practice_game, $game_id);
+  public static function new_game(bool $practice_game, string $game_id, string $msg_id): array {
+    $gato = new Gato(0, 0, $practice_game, $game_id,$msg_id);
     return $gato->state_to_json();
   }
 }

--- a/app/Services/GatoService.php
+++ b/app/Services/GatoService.php
@@ -50,7 +50,7 @@ class GatoService
         if($move_by == True && $move[6] == 'user' && !$practice_game) return; //When a user tries to play twice.
         if($move_by == False && $move[6] == 'agent') return; //When the agent tries to play twice.
 
-        $gato = new Gato((int) $move[2], (int) $move[3], $practice_game, $game_id);
+        $gato = new Gato((int) $move[2], (int) $move[3], $practice_game, $game_id,$message_id);
         $gato->move((int) $move[1], $move_by);
 
         //Indicates the player who threw the last turn, only if it was a valid movement.
@@ -70,7 +70,7 @@ class GatoService
          * for the game_id, for that reason we add +1 to update in the next  
          * message and no the message used fot the game_id.
          */
-        update_keyboard($chatId, $game_id+1, $board_state);
+        update_keyboard($chatId, $message_id, $board_state);
 
         $game_status = $gato->status();
         $win = 3;

--- a/database/migrations/2021_08_12_160605_create_games_table.php
+++ b/database/migrations/2021_08_12_160605_create_games_table.php
@@ -14,7 +14,7 @@ class CreateGamesTable extends Migration
     public function up()
     {
         Schema::create('games', function (Blueprint $table) {
-            $table->id()->unique();
+            $table->id();
             $table->foreignId('telegram_user_id')->nullable()->index();
             $table->tinyInteger('state')->default(0);
             $table->tinyInteger('winner')->nullable();

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -21347,6 +21347,7 @@ __webpack_require__.r(__webpack_exports__);
       var black = parseInt(data[3], 10);
       var game_id = data[5];
       var turn = data[6];
+      var msg_id = data[7];
       var board = [];
       var row = [];
 
@@ -21359,9 +21360,9 @@ __webpack_require__.r(__webpack_exports__);
 
         var mask = 1 << i;
         var tile = ' ';
-        if ((mask & white) != 0) tile = 'O';else if ((mask & black) != 0) tile = 'X'; //          symbol, idx, bitmask p1,bitmask p1,player type,game_id,turn
+        if ((mask & white) != 0) tile = 'O';else if ((mask & black) != 0) tile = 'X'; //          symbol, idx, bitmask p1,bitmask p1,player type,game_id,turn,msg_id
 
-        var data = "".concat(tile, ",").concat(i, ",").concat(white, ",").concat(black, ",false,").concat(game_id, ",").concat(turn);
+        var data = "".concat(tile, ",").concat(i, ",").concat(white, ",").concat(black, ",false,").concat(game_id, ",").concat(turn, ",").concat(msg_id);
         row.push({
           "text": tile,
           "callback_data": data
@@ -21785,7 +21786,7 @@ function _asyncToGenerator(fn) { return function () { var self = this, args = ar
       this.message = "";
     },
     move: function move(data) {
-      var msgId = data.split(",")[5];
+      var msgId = data.split(",")[7];
       postData("/telegram-update", {
         callback_query: {
           data: data,

--- a/resources/js/Pages/Chat/Board.vue
+++ b/resources/js/Pages/Chat/Board.vue
@@ -34,6 +34,7 @@ export default {
             const black = parseInt(data[3], 10);
             const game_id = data[5];
             const turn = data[6];
+            const msg_id = data[7];
 
             var board = [];
             var row = [];
@@ -51,8 +52,8 @@ export default {
                 if ((mask & white) != 0) tile = 'O';
                 else if ((mask & black) != 0) tile = 'X';
 
-                //          symbol, idx, bitmask p1,bitmask p1,player type,game_id,turn
-                var data = `${tile},${i},${white},${black},false,${game_id},${turn}`;
+                //          symbol, idx, bitmask p1,bitmask p1,player type,game_id,turn,msg_id
+                var data = `${tile},${i},${white},${black},false,${game_id},${turn},${msg_id}`;
                 row.push({"text":tile,"callback_data":data});
                 
             }

--- a/resources/js/Pages/Chat/Index.vue
+++ b/resources/js/Pages/Chat/Index.vue
@@ -371,7 +371,7 @@ export default {
       this.message = "";
     },
     move(data) {
-      var msgId = data.split(",")[5];
+      var msgId = data.split(",")[7];
       postData("/telegram-update", {
         callback_query: {
           data: data,


### PR DESCRIPTION
Para solucionar este problema se crea el juego antes de crear una instancia del Gato para pasarla en su constructor como  msg_id que permitirá identificar el mensaje más adelante y poder actualizar el tablero.

El único detalle que si es bastante importante es que la estructura de la bd cambia a incrementable, pero ya hice una prueba y no hay problema, se comienzan a crear a partir del ultimo registro que se tiene y ya no existe duplicidad.